### PR TITLE
ES-1597 Remove goroutines

### DIFF
--- a/dependabot/dependabot.go
+++ b/dependabot/dependabot.go
@@ -28,7 +28,7 @@ func Start(ctx context.Context, client *github.Client) {
 	// Loop through all repos
 	for _, repository := range repos {
 		// wg.Add(1)
-		go checkRepo(ctx, client, repository)
+		checkRepo(ctx, client, repository)
 	}
 	// wg.Wait()
 }


### PR DESCRIPTION
Oliver pointed out, it being a good idea to remove `go` before `checkRepo`