### PR TITLE
ES-1880: dependabot-circleci doesn't close the old pull request if it gets superseded

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   BESTSELLER/engineering-services
+*   @BESTSELLER/engineering-services

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   BESTSELLER/engineering-services

--- a/circleci/orb.go
+++ b/circleci/orb.go
@@ -34,8 +34,8 @@ func findNewestOrbVersion(orb string) string {
 	orbSplitString := strings.Split(orb, "@")
 
 	// check if orb is always updated
-	if orbSplitString[1] == "volatile" {
-		return "volatile"
+	if orbSplitString[1] == "volatile" || strings.HasPrefix(orbSplitString[1], "dev:") {
+		return orbSplitString[1]
 	}
 
 	client := graphql.NewClient(http.DefaultClient, "https://circleci.com/", "graphql-unstable", "", false)

--- a/main.go
+++ b/main.go
@@ -17,6 +17,17 @@ import (
 var wg sync.WaitGroup
 
 func init() {
+	err := config.LoadEnvConfig()
+	logger.Init()
+
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to read env config")
+	}
+
+	if _, err := os.Stat(config.EnvVars.Config); err == nil {
+		return
+	}
+
 	vaultAddr := os.Getenv("VAULT_ADDR")
 	if vaultAddr == "" {
 		log.Fatal().Msg("VAULT_ADDR must be set")
@@ -49,14 +60,8 @@ func init() {
 }
 
 func main() {
-	err := config.LoadEnvConfig()
-	logger.Init()
 
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to read env config")
-	}
-
-	err = config.ReadConfig(config.EnvVars.Config)
+	err := config.ReadConfig(config.EnvVars.Config)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to read github app config:")
 	}


### PR DESCRIPTION
This should fix so that it will close all earlier pull requests, not just the latest one.
I have tested it on [bestone-bi4-sales-core-salesorderservice](https://github.com/BESTSELLER/bestone-bi4-sales-core-salesorderservice/pulls) and [tester](https://github.com/BESTSELLER/tester/pulls) and it seems to work.