### PR TITLE
Adressing error logs

### DIFF
--- a/api/config_check.go
+++ b/api/config_check.go
@@ -36,7 +36,7 @@ func (h *ConfigCheckHandler) Handles() []string {
 }
 
 // Handle has ALL the logic! ;)
-func (h *ConfigCheckHandler) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+func (h *ConfigCheckHandler) Handle(ctx context.Context, _, _ string, payload []byte) error {
 	start := time.Now()
 	var event github.PushEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
@@ -56,6 +56,12 @@ func (h *ConfigCheckHandler) Handle(ctx context.Context, eventType, deliveryID s
 	if err != nil {
 		log.Error().Err(err).Msgf("Inserting into bigquery table, had the following error: %s", err)
 		return err
+	}
+
+	_, _, err = client.Git.GetRef(ctx, Githubinfo.Owner, Githubinfo.RepoName, commitSHA)
+	if err != nil {
+		log.Warn().Err(err).Msg("event.GetAfter() SHA not found")
+		return nil // we dont care
 	}
 
 	// get content

--- a/api/controller.go
+++ b/api/controller.go
@@ -64,9 +64,19 @@ func controllerHandler(w http.ResponseWriter, _ *http.Request) {
 				return
 			}
 
-			err = PostJSON(fmt.Sprintf("%s/start", config.EnvVars.WorkerURL), payloadBytes)
+			resp, err := PostJSON(fmt.Sprintf("%s/start", config.EnvVars.WorkerURL), payloadBytes)
 			if err != nil {
-				log.Error().Err(err).Msgf("error triggering worker for org %s", org)
+				if resp != nil && resp.StatusCode == http.StatusNotAcceptable {
+					log.Warn().Err(err).Msgf("dependabot-circleci not installed on org %s ", org)
+					for _, repo := range repos {
+						err := db.DeleteRepo(repo, context.Background())
+						if err != nil {
+							log.Error().Err(err).Msgf("error deleting repo %s", repo.Repo)
+						}
+					}
+				} else {
+					log.Error().Err(err).Msgf("error triggering worker for org %s", org)
+				}
 			} else {
 				log.Debug().Msgf("Dependency check has started for org: %s", org)
 			}
@@ -93,8 +103,7 @@ func shouldRun(schedule string) bool {
 }
 
 // PostJSON posts the structs as json to the specified url
-func PostJSON(url string, payload []byte) error {
-
+func PostJSON(url string, payload []byte) (*http.Response, error) {
 	var myClient *http.Client
 	clientWithAuth, err := idtoken.NewClient(context.Background(), url)
 	if err != nil {
@@ -107,13 +116,13 @@ func PostJSON(url string, payload []byte) error {
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
 	if err != nil {
-		return fmt.Errorf("unable to create request: %s", err)
+		return nil, fmt.Errorf("unable to create request: %s", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AppConfig.HTTP.Token))
 	r, err := myClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("unable to do request: %s", err)
+		return nil, fmt.Errorf("unable to do request: %s", err)
 	}
 	defer r.Body.Close()
 
@@ -121,9 +130,9 @@ func PostJSON(url string, payload []byte) error {
 	if r.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(r.Body)
 		bodyString := string(bodyBytes)
-		return fmt.Errorf("request failed, expected status: %d got: %d, error message: %s", http.StatusOK, r.StatusCode, bodyString)
+		return r, fmt.Errorf("request failed, expected status: %d got: %d, error message: %s", http.StatusOK, r.StatusCode, bodyString)
 	}
-	return nil
+	return r, nil
 }
 
 func pullRepos() (repos map[string][]db.RepoData, err error) {

--- a/circleci/orb.go
+++ b/circleci/orb.go
@@ -70,7 +70,7 @@ func findNewestOrbVersion(currentVersion string, parameters *map[string]*yaml.No
 	// if requests fails, return current version
 	orbInfo, err := api.OrbInfo(client, orbName)
 	if err != nil {
-		log.Error().Err(err).Msgf("error finding latests orb version failed for orb: %s", orbSplitString[0])
+		log.Warn().Err(err).Msgf("error finding latests orb version failed for orb: %s", orbSplitString[0])
 		return orbName, currentTag, currentTag
 	}
 	highestVersion, err := version.NewVersion(orbInfo.Orb.HighestVersion)

--- a/db/db.go
+++ b/db/db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-
 	"github.com/BESTSELLER/dependabot-circleci/config"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
@@ -69,4 +68,16 @@ func GetRepos(ctx context.Context) (repos []RepoData, err error) {
 		return nil, err
 	}
 	return repos, nil
+}
+
+func DeleteRepo(repo RepoData, ctx context.Context) error {
+	db := DBClient()
+	_, err := db.NewDelete().
+		Model(&repo).
+		Where("id = ?", repo.ID).
+		Exec(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/dependabot/dependabot.go
+++ b/dependabot/dependabot.go
@@ -178,8 +178,12 @@ func gatherUpdates(wg *sync.WaitGroup, entityCount *atomic.Int32, ctx context.Co
 	log.Info().Msgf("Processing: %s", pathInRepo)
 	// 1. Get directory contents
 	options := &github.RepositoryContentGetOptions{Ref: repoInfo.targetBranch}
-	fileContent, directoryContent, _, err := client.Repositories.GetContents(context.Background(), repoInfo.repoOwner, repoInfo.repoName, pathInRepo, options)
+	fileContent, directoryContent, resp, err := client.Repositories.GetContents(context.Background(), repoInfo.repoOwner, repoInfo.repoName, pathInRepo, options)
 	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			log.Error().Err(err).Msgf("file not found %s", repoInfo.repoName)
+			return
+		}
 		log.Error().Err(err).Msgf("could not parseRepoContent %s", repoInfo.repoName)
 		return
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   worker:
     environment:

--- a/gh/commit.go
+++ b/gh/commit.go
@@ -109,7 +109,7 @@ func CreatePR(ctx context.Context, client *github.Client, repoOwner string, repo
 	if len(singleReviewers) > 0 || len(teamReviewers) > 0 {
 		_, _, err = client.PullRequests.RequestReviewers(ctx, repoOwner, repoName, pr.GetNumber(), github.ReviewersRequest{Reviewers: singleReviewers, TeamReviewers: teamReviewers})
 		if err != nil {
-			log.Error().Str("repo_name", repoName).Err(err).Msg("Failed to request reviewers")
+			log.Warn().Str("repo_name", repoName).Err(err).Msg("Failed to request reviewers")
 		}
 	}
 


### PR DESCRIPTION
* Fixed:  "no commit with sha", now we check for ref to make sure it's a valid SHA
`POST https://api.github.com/repos/BESTSELLER/bestone-bi4-log-transfer-order-core/check-runs:  422 No commit found for SHA: a560441e079d91c4afb9b39810aaa826e6155dc2 []`
* Fixed: dependabot-circleci trying to run on orgs it has been uninstalled from
* Enhancement: If dependabot-circleci is uninstalled from an org then the repos are cleaned from the database on next run.
* Enhancement: Improved logging by lowering loglevel from error to warn in case we cannot determine newest orb version. All instances of this have been due to rate limit
* Enhancement: Improved logging by differentiating between other errors and file not found