### PR TITLE
Bump harpocrates to 2.8.3

### DIFF
--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -63,7 +63,7 @@ resource "google_cloud_run_v2_service" "main" {
     }
     containers {
       name  = "secret-dumper"
-      image = "europe-docker.pkg.dev/artifacts-pub-prod-b57f/public-docker/harpocrates:2.4.0"
+      image = "europe-docker.pkg.dev/artifacts-pub-prod-b57f/public-docker/harpocrates:2.8.3"
       args = [
         jsonencode({
           "format" : "json",


### PR DESCRIPTION
Trying to fix [this](https://console.cloud.google.com/logs/query;aroundTime=2025-02-06T04:00:01.996528Z;cursorTimestamp=2025-02-06T04:08:56.240232910Z;duration=PT1H;pinnedLogId=2025-02-06T04:00:01.996528Z%2F67a435d80003d1c89265a9bc;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22controller%22%0Aresource.labels.location%20%3D%20%22europe-west4%22%0A%20severity%3E%3DDEFAULT%0A-jsonPayload.path%3D%22%2Fhealthz%22%0Atimestamp%3D%222025-02-06T04:08:55Z%22%0AinsertId%3D%2267a435d7000bea2b9e61098e%22;storageScope=project?project=dependabot-pub-prod-586e) - just so people can get the final pull requests